### PR TITLE
v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.2
+
+- Normalize JS-side QR options consistently across native and web before generation.
+- Validate invalid error-correction levels and inverted version ranges before crossing native or web QR generation boundaries.
+
 ## 0.0.1
 
 - Initial QR-only Nitro module.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-nitro-qrcode
 
-[![npm](https://img.shields.io/badge/npm-v0.0.1-orange)](https://www.npmjs.com/package/react-native-nitro-qrcode)
+[![npm](https://img.shields.io/badge/npm-v0.0.2-orange)](https://www.npmjs.com/package/react-native-nitro-qrcode)
 [![license](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
 ![react-native](https://img.shields.io/badge/react--native-%3E%3D0.75-61dafb)
 ![nitro-modules](https://img.shields.io/badge/nitro--modules-%3E%3D0.35.4-black)

--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
     },
     "packages/react-native-nitro-qrcode": {
       "name": "react-native-nitro-qrcode",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "qrcode": "^1.5.4",
       },

--- a/packages/react-native-nitro-qrcode/package.json
+++ b/packages/react-native-nitro-qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-qrcode",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Fast QR code generator for React Native and Expo with Nitro, native C++, PNG export, gradients, and no react-native-svg or Skia.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-qrcode/src/__tests__/index.test.tsx
+++ b/packages/react-native-nitro-qrcode/src/__tests__/index.test.tsx
@@ -59,6 +59,7 @@ class ErrorBoundary extends React.Component<
 
 import {
   clearQRCodeCache,
+  type ErrorCorrectionLevel,
   getMatrix,
   getQRCodeCacheSize,
   NitroQRCode,
@@ -138,7 +139,7 @@ describe("native QRCode API", () => {
       "Hello",
       256,
       2,
-      "high",
+      "H",
       "#111111",
       "#EEEEEE",
       2,
@@ -258,6 +259,20 @@ describe("native QRCode API", () => {
     });
   });
 
+  it("normalizes native error-correction aliases and colors", () => {
+    toPngBase64({
+      value: "low",
+      errorCorrectionLevel: "low",
+      foregroundColor: "#abcdef",
+    });
+    toPngBase64({ value: "medium", errorCorrectionLevel: "medium" });
+    toPngBase64({ value: "quartile", errorCorrectionLevel: "quartile" });
+
+    const calls = mockHybridObject.generatePngBase64.mock.calls as unknown[][];
+    expect(calls.map((call) => call[3])).toEqual(["L", "M", "Q"]);
+    expect(calls[0][4]).toBe("#ABCDEF");
+  });
+
   it("exposes cache helpers and grouped API", () => {
     clearQRCodeCache();
     expect(mockHybridObject.clearCache).toHaveBeenCalled();
@@ -278,7 +293,16 @@ describe("native QRCode API", () => {
     expect(() => toPngBase64({ value: "x", maxVersion: 41 })).toThrow(
       "maxVersion must be",
     );
+    expect(() =>
+      toPngBase64({ value: "x", minVersion: 3, maxVersion: 2 }),
+    ).toThrow("minVersion and maxVersion");
     expect(() => toPngBase64({ value: "x", mask: 8 })).toThrow("mask must be");
+    expect(() =>
+      toPngBase64({
+        value: "x",
+        errorCorrectionLevel: "bad" as ErrorCorrectionLevel,
+      }),
+    ).toThrow("errorCorrectionLevel must be");
     expect(() => toPngBase64({ value: "x", size: 1.5 })).toThrow(
       "size must be",
     );
@@ -811,9 +835,18 @@ describe("web QRCode API", () => {
     expect(() => Web.toSvgString({ value: "x", maxVersion: 41 })).toThrow(
       "maxVersion must be",
     );
+    expect(() =>
+      Web.toSvgString({ value: "x", minVersion: 3, maxVersion: 2 }),
+    ).toThrow("minVersion and maxVersion");
     expect(() => Web.toSvgString({ value: "x", mask: 8 })).toThrow(
       "mask must be",
     );
+    expect(() =>
+      Web.toSvgString({
+        value: "x",
+        errorCorrectionLevel: "bad" as Web.ErrorCorrectionLevel,
+      }),
+    ).toThrow("errorCorrectionLevel must be");
     expect(() =>
       Web.toSvgString({
         value: "x",

--- a/packages/react-native-nitro-qrcode/src/index.ts
+++ b/packages/react-native-nitro-qrcode/src/index.ts
@@ -407,7 +407,7 @@ export const NitroQRCode = {
 type NormalizedOptions = Required<
   Omit<QRCodeOptions, "errorCorrectionLevel" | "shapeOptions" | "gradient">
 > & {
-  errorCorrectionLevel: string;
+  errorCorrectionLevel: "L" | "M" | "Q" | "H";
   shapeOptions: Required<QRCodeShapeOptions>;
   gradient: NormalizedGradient;
 };
@@ -443,6 +443,21 @@ function normalizeOptions(options: QRCodeOptions): NormalizedOptions {
     2048,
   );
   validateLogoDimensions(logoAreaSize, logoAreaBorderRadius, size);
+  const minVersion = sanitizeInteger(
+    options.minVersion,
+    DEFAULT_MIN_VERSION,
+    "minVersion",
+    1,
+    40,
+  );
+  const maxVersion = sanitizeInteger(
+    options.maxVersion,
+    DEFAULT_MAX_VERSION,
+    "maxVersion",
+    1,
+    40,
+  );
+  validateVersionRange(minVersion, maxVersion);
 
   return {
     value: options.value,
@@ -454,24 +469,20 @@ function normalizeOptions(options: QRCodeOptions): NormalizedOptions {
       0,
       32,
     ),
-    errorCorrectionLevel: options.errorCorrectionLevel ?? DEFAULT_ECL,
-    foregroundColor: options.foregroundColor ?? DEFAULT_FOREGROUND,
-    backgroundColor: options.backgroundColor ?? DEFAULT_BACKGROUND,
+    errorCorrectionLevel: normalizeEcl(
+      options.errorCorrectionLevel ?? DEFAULT_ECL,
+    ),
+    foregroundColor: sanitizeColor(
+      options.foregroundColor ?? DEFAULT_FOREGROUND,
+      "foregroundColor",
+    ),
+    backgroundColor: sanitizeColor(
+      options.backgroundColor ?? DEFAULT_BACKGROUND,
+      "backgroundColor",
+    ),
     gradient: normalizeGradient(options.gradient),
-    minVersion: sanitizeInteger(
-      options.minVersion,
-      DEFAULT_MIN_VERSION,
-      "minVersion",
-      1,
-      40,
-    ),
-    maxVersion: sanitizeInteger(
-      options.maxVersion,
-      DEFAULT_MAX_VERSION,
-      "maxVersion",
-      1,
-      40,
-    ),
+    minVersion,
+    maxVersion,
     mask: sanitizeInteger(options.mask, DEFAULT_MASK, "mask", -1, 7),
     boostEcl: options.boostEcl ?? DEFAULT_BOOST_ECL,
     shapeOptions: normalizeShapeOptions(options.shapeOptions),
@@ -643,6 +654,14 @@ function validateLogoDimensions(
   }
 }
 
+function validateVersionRange(minVersion: number, maxVersion: number): void {
+  if (minVersion > maxVersion) {
+    throw new Error(
+      "minVersion and maxVersion must be between 1 and 40, with minVersion <= maxVersion.",
+    );
+  }
+}
+
 function scaleShapeOptions(
   options: QRCodeShapeOptions | undefined,
   scale: number,
@@ -661,6 +680,19 @@ function scaleShapeOptions(
         ? undefined
         : Math.round(options.eyePatternGap * scale),
   };
+}
+
+function normalizeEcl(value: ErrorCorrectionLevel): "L" | "M" | "Q" | "H" {
+  if (value === "L" || value === "M" || value === "Q" || value === "H") {
+    return value;
+  }
+  if (value === "low") return "L";
+  if (value === "medium") return "M";
+  if (value === "quartile") return "Q";
+  if (value === "high") return "H";
+  throw new Error(
+    "errorCorrectionLevel must be L, M, Q, H, low, medium, quartile, or high.",
+  );
 }
 
 function sanitizeInteger(

--- a/packages/react-native-nitro-qrcode/src/index.web.ts
+++ b/packages/react-native-nitro-qrcode/src/index.web.ts
@@ -413,6 +413,21 @@ function normalizeOptions(options: QRCodeOptions): NormalizedOptions {
     2048,
   );
   validateLogoDimensions(logoAreaSize, logoAreaBorderRadius, size);
+  const minVersion = sanitizeInteger(
+    options.minVersion,
+    DEFAULT_MIN_VERSION,
+    "minVersion",
+    1,
+    40,
+  );
+  const maxVersion = sanitizeInteger(
+    options.maxVersion,
+    DEFAULT_MAX_VERSION,
+    "maxVersion",
+    1,
+    40,
+  );
+  validateVersionRange(minVersion, maxVersion);
 
   return {
     value: options.value,
@@ -436,20 +451,8 @@ function normalizeOptions(options: QRCodeOptions): NormalizedOptions {
       "backgroundColor",
     ),
     gradient: normalizeGradient(options.gradient),
-    minVersion: sanitizeInteger(
-      options.minVersion,
-      DEFAULT_MIN_VERSION,
-      "minVersion",
-      1,
-      40,
-    ),
-    maxVersion: sanitizeInteger(
-      options.maxVersion,
-      DEFAULT_MAX_VERSION,
-      "maxVersion",
-      1,
-      40,
-    ),
+    minVersion,
+    maxVersion,
     mask: sanitizeInteger(options.mask, DEFAULT_MASK, "mask", -1, 7),
     boostEcl: options.boostEcl ?? DEFAULT_BOOST_ECL,
     shapeOptions: normalizeShapeOptions(options.shapeOptions),
@@ -625,6 +628,14 @@ function validateLogoDimensions(
   }
 }
 
+function validateVersionRange(minVersion: number, maxVersion: number): void {
+  if (minVersion > maxVersion) {
+    throw new Error(
+      "minVersion and maxVersion must be between 1 and 40, with minVersion <= maxVersion.",
+    );
+  }
+}
+
 function scaleShapeOptions(
   options: QRCodeShapeOptions | undefined,
   scale: number,
@@ -646,11 +657,16 @@ function scaleShapeOptions(
 }
 
 function normalizeEcl(value: ErrorCorrectionLevel): "L" | "M" | "Q" | "H" {
+  if (value === "L" || value === "M" || value === "Q" || value === "H") {
+    return value;
+  }
   if (value === "low") return "L";
   if (value === "medium") return "M";
   if (value === "quartile") return "Q";
   if (value === "high") return "H";
-  return value;
+  throw new Error(
+    "errorCorrectionLevel must be L, M, Q, H, low, medium, quartile, or high.",
+  );
 }
 
 function sanitizeInteger(


### PR DESCRIPTION
## Summary
- prepare `react-native-nitro-qrcode@0.0.2` as a patch release candidate
- normalize native QR options before crossing the Nitro bridge, matching web behavior for ECL aliases and color validation
- reject invalid ECL values and inverted `minVersion` / `maxVersion` ranges consistently on native and web
- add regression coverage and update README/changelog/version metadata

## Verification
- `bun install --frozen-lockfile`
- `bun run check`
- `bunx expo install --check` from `apps/example`
- `bunx expo-doctor@latest` from `apps/example`
- `bun run example:prebuild`
- `bun run --cwd apps/example android -- --port 8082` built, installed on `Pixel_9`, started Metro on 8082, and bundled successfully
- `bun run --cwd apps/example ios -- --no-bundler` built, installed, and opened on `iPhone 17 Pro Max`; iOS emitted only existing warnings (`-lc++` duplicate library and SDWebImage deployment target mismatch)
- `bun run publish-package:dry-run` passed for `react-native-nitro-qrcode@0.0.2`; dry pack included 64 files, unpacked size 0.39 MB

## Release Draft
# Changes
- Normalize QR error-correction aliases before native bridge calls.
- Sanitize native foreground/background colors consistently with web.
- Reject invalid error-correction levels and `minVersion > maxVersion` on native and web.
- Add regression coverage for option normalization and validation.

## Notes
- `bun audit` still reports transitive Expo/tooling advisories. I did not add overrides because Expo SDK validation and Doctor pass, and broad nested dependency overrides would be higher risk for this patch candidate.
- No npm publish, tag, or GitHub release was created.
