### PR TITLE
Install LLVM in npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Setup LLVM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
Install the LLVM toolchain in the npm publish workflow so the release gate can run C++ coverage before publishing.

## Changes
- Add the same clang/llvm setup used by CI to `.github/workflows/npm-publish.yml`.

## Why
The `v0.2.0` release workflow failed before publish because `llvm-profdata` was missing on the GitHub runner.

## Test
- `bun run check`