### PR TITLE
Release QRCode 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.2
+
+- Shipped the current package artifact with the README, badges, compatibility
+  table, option reference, and TypeScript guidance aligned to the package API.
+- Kept native and web QR component behavior consistent by sharing option
+  normalization, validation, and component generation logic across entrypoints.
+- Hardened public TypeScript contracts for QRCode colors, gradients, versions,
+  masks, layouts, and component props.
+
 ## 0.4.1
 
 - Avoided redundant `<QRCode />` regeneration when nested `shapeOptions` or
@@ -10,8 +19,8 @@
   typed boolean instead of checking the error array manually.
 - Tightened `logoBackgroundColor` to the same typed background color surface as
   QR output.
-- Updated README examples, compatibility notes, option tables, and TypeScript
-  guidance to match the current package API.
+- Updated README examples, badges, compatibility notes, option tables, and
+  TypeScript guidance to match the current package API.
 
 ## 0.4.0
 

--- a/packages/react-native-nitro-qrcode/package.json
+++ b/packages/react-native-nitro-qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-qrcode",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Fast QR code generator for React Native and Expo with Nitro, native C++, PNG export, gradients, and no react-native-svg or Skia.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
# Changes
- Bump `react-native-nitro-qrcode` to `0.4.2`.
- Add the `0.4.2` changelog entry for the current package artifact, README/API documentation alignment, shared native/web component logic, and hardened public TypeScript contracts.
- Keep `0.4.1` documented as the already-published package version.