### PR TITLE
fix: preserve qrcode validation error typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ Breaking changes are always listed first in each release section.
 - Added `getMatrixObject()` returning `{ size, packedBase64 }` in a single
   bridge crossing and `getCacheBytes()` for byte-accurate cache accounting;
   `getMatrixSize()` + `getMatrixPackedBase64()` remain available.
-- Exposed `QRCodeKnownValidationErrorCode` for stable package-known codes while
-  allowing `QRCodeValidationError.code` to remain a string for forward-compatible
-  native validation codes.
+- Exposed the additive `QRCodeKnownValidationErrorCode` alias while preserving
+  the established `QRCodeValidationError.code` and `QRCodeValidationErrorCode`
+  literal union for strict TypeScript consumers.
 
 ## [0.6.0] - 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ warnings. With `scanSafe: "strict"`, scanability warnings are also returned as
 errors so forms and design tooling can block risky output before rendering.
 
 Errors are deterministic: validation returns typed `QRCodeValidationResult`
-entries with string codes. `invalid` and the scanability warning codes are the
-package-known values exposed by `QRCodeKnownValidationErrorCode`; consumers
-should keep handling unknown codes defensively because native integrations can
-introduce additional codes. Generation failures throw (or reject with) `Error` instances;
+entries with `QRCodeValidationErrorCode` values. `invalid` and the scanability
+warning codes are the package-known values exposed by
+`QRCodeKnownValidationErrorCode`. Generation failures throw (or reject with)
+`Error` instances;
 message text is never used for control flow. The JavaScript layer validates
 all options before the native boundary, so the native side surfaces unexpected
 failures as ordinary exceptions rather than a separate error envelope.

--- a/packages/react-native-nitro-qrcode/src/__tests__/public-types.test-d.ts
+++ b/packages/react-native-nitro-qrcode/src/__tests__/public-types.test-d.ts
@@ -172,8 +172,9 @@ expectFalse<IsAssignable<"custom", QRCodePreset>>();
 expectFalse<IsAssignable<"always", NonNullable<QRCodeOptions["scanSafe"]>>>();
 expectFalse<IsAssignable<"unknown", QRCodeKnownValidationErrorCode>>();
 expectFalse<IsAssignable<"unknown", QRCodeValidationErrorCode>>();
-const extensibleValidationCode: string = validation.errors[0]?.code ?? "";
-void extensibleValidationCode;
+const knownValidationCode: QRCodeValidationErrorCode =
+  validation.errors[0]?.code ?? "invalid";
+void knownValidationCode;
 expectFalse<
   IsAssignable<
     (uri: number) => void,

--- a/packages/react-native-nitro-qrcode/src/validation.ts
+++ b/packages/react-native-nitro-qrcode/src/validation.ts
@@ -182,7 +182,7 @@ export type QRCodeKnownValidationErrorCode =
 export type QRCodeValidationErrorCode = QRCodeKnownValidationErrorCode;
 
 export type QRCodeValidationError = {
-  code: string;
+  code: QRCodeValidationErrorCode;
   message: string;
 };
 


### PR DESCRIPTION
# Changes

- Restore `QRCodeValidationError.code` to the literal union shipped in 0.6.x, preserving strict TypeScript compatibility for existing consumers.
- Keep `QRCodeKnownValidationErrorCode` as an additive alias and align the README, CHANGELOG, and declaration test with the preserved public contract.
- Breaking changes: none; this follow-up removes an accidental type widening before publication.
