### PR TITLE
Accelerate QR generation and preview rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,26 +10,34 @@ Breaking changes are always listed first in each release section.
 
 ### Breaking changes
 
-- None for consumers upgrading from 0.6.x. Direct upgrades from 0.5.x or
-  earlier still require the Nitro Modules 0.37 native rebuild documented in
-  the 0.6.0 release.
+- None.
 
 ### Changed
 
+- Replaced the native PNG encoder's byte-at-a-time CRC loop with zlib's
+  optimized chunked `crc32` implementation; generated PNG bytes and validation
+  behavior are unchanged.
+- Cleared the QR preview's accessibility busy state after async generation so
+  assistive technology receives the completed preview state.
 - Restored the four positional native PNG methods as deprecated wrappers over
   the object-based methods, so existing native callers continue to work.
 - Bounded the native matrix cache to 32 entries or 512 KiB and exposed a
   default combined native output/matrix cache bound of 4.5 MiB.
-- Preserved the established SVG serialization: one `1x1` path segment per dark
-  module and the normalized color spelling in the returned string. SVG cache
-  requests keep spelling-sensitive keys; PNG cache requests still use parsed
-  color bytes.
+- Preserved native SVG serialization: one `1x1` path segment per dark module
+  and the normalized color spelling in the returned string. Web SVG retains its
+  horizontal-run serialization. SVG cache requests keep spelling-sensitive
+  keys; PNG cache requests still use parsed color bytes.
 - Added `getMatrixObject()` returning `{ size, packedBase64 }` in a single
   bridge crossing and `getCacheBytes()` for byte-accurate cache accounting;
   `getMatrixSize()` + `getMatrixPackedBase64()` remain available.
 - Exposed the additive `QRCodeKnownValidationErrorCode` alias while preserving
   the established `QRCodeValidationError.code` and `QRCodeValidationErrorCode`
   literal union for strict TypeScript consumers.
+- Direct upgrades from 0.5.x or earlier still require the Nitro Modules 0.37
+  native rebuild documented in the 0.6.0 release.
+- Clarified object-API compatibility, native/web SVG serialization, PNG-only
+  logo-area clearing, scan-safe customization, and the isolated benchmark
+  scope without changing defaults or encoded PNG/SVG bytes.
 
 ## [0.6.0] - 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ const matrix = getMatrix(options);
 Async PNG helpers are useful for UI flows that should yield before native
 generation completes.
 
+The exported `NitroQRCode` object exposes the same PNG, SVG, matrix, validation,
+cache, and metrics helpers for callers that prefer an object API. Native
+`HybridQRCode` integrations should use the object-shaped methods
+`generatePngBase64Object`, `generatePngBase64AsyncObject`,
+`generatePngDataUriObject`, and `generatePngDataUriAsyncObject`. The four older
+positional PNG methods remain available only as deprecated compatibility
+wrappers; they are not used by the JavaScript entrypoints.
+
 `getMatrix` returns the QR symbol size and a Base64-encoded, row-major bitset.
 Each module uses one bit, most-significant bit first; dark modules are `1`.
 Rendering-only options such as colors, size, shapes, gradients, and logo area do
@@ -200,8 +208,9 @@ not change this encoding result.
 
 `toSvgString` exports the encoded matrix with quiet zone, background,
 foreground, and gradient settings. Component-only logo nodes are not embedded
-in PNG or SVG exports. Set `logoAreaSize` when an exported image needs a clear
-center area for a logo added by another tool.
+in PNG or SVG exports. PNG rendering clears the configured `logoAreaSize`; SVG
+does not reserve or clear a logo area, so reserve that space in the consuming
+SVG tool if needed.
 
 Native and web output caches verify the full normalized request after hashed
 lookup. Each cache retains at most 128 entries or 4 MiB, whichever limit is
@@ -216,10 +225,13 @@ Native matrix export reuses a small bounded least-recently-used cache (32
 entries or 512 KiB, whichever comes first) and returns the size and packed data
 through one `getMatrixObject` bridge call. The native output cache retains at
 most 4 MiB, so the default combined native output and matrix cache bound is
-4.5 MiB. The native cache memory report includes both output and matrix cache
-bytes. SVG serialization keeps the established output contract: each dark
-module is emitted as its own `1x1` path segment, and normalized color spellings
-such as `transparent` and `#00000000` remain observable in the returned string.
+4.5 MiB. `getQRCodeCacheBytes()` reports retained native output-cache bytes;
+Nitro's native external-memory report also accounts for the matrix cache. Native
+SVG serialization keeps the established output contract: each dark module is
+emitted as its own `1x1` path segment. Web SVG keeps its existing equivalent
+horizontal-run serialization. Normalized color spellings such as `transparent`
+and `#00000000` remain observable in the returned string where that platform
+entry preserves them.
 PNG cache keys still use parsed color bytes so equivalent PNG requests can
 share entries without changing their pixels.
 
@@ -266,8 +278,8 @@ Generation input bounds:
 Option loss and platform differences:
 
 - **SVG output** encodes the matrix with quiet zone, background, foreground,
-  and gradient only. Body shape, gaps, density, stroke, eye, and eyeball
-  colors do not apply to the SVG path.
+  and gradient only. Body shape, gaps, density, stroke, eye, eyeball colors,
+  and logo-area clearing do not apply to the SVG path.
 - **Web PNG transparency** uses an alpha-cleared background; transparent
   pixels are truly transparent instead of black.
 - **Circle geometry** is defined as an ellipse inscribed in the module cell on
@@ -295,15 +307,16 @@ reports a busy state while generation is pending, and the logo overlay is
 hidden from the accessibility tree. Screen readers announce the QR meaning
 and its generation state on iOS and Android.
 
-The `logo` prop is a React node layered above the generated image. Only
-`logoAreaSize` clears QR pixels and reserves room in the encoded image.
+The `logo` prop is a React node layered above the generated PNG. Only
+`logoAreaSize` clears PNG pixels and reserves room in the encoded image.
 `logoPadding` and `logoBackgroundColor` style the overlay but do not reserve
 additional modules. When `logo` is present and `logoAreaSize` is omitted, the
 component reserves 28% of `size`. Keep the logo area near or below 30% for
 reliable scanning.
 
-With `scanSafe`, quiet zones smaller than four modules are raised to four.
-When a logo area is present, error correction is raised to `H`.
+With `scanSafe`, quiet zones smaller than four modules are raised to four. When
+`scanSafe` is enabled with a non-zero logo area, error correction is raised to
+`H`.
 `scanSafe: "strict"` additionally converts scanability warnings into validation
 errors.
 
@@ -379,6 +392,8 @@ Main exports:
 - `toPngBase64Async` and `toPngDataUriAsync`.
 - `validateOptions`.
 - `clearQRCodeCache`, `getQRCodeCacheSize`, and `getQRCodeCacheBytes`.
+- `getQRCodeMetrics`, `resetQRCodeMetrics`, and
+  `setQRCodeMetricsEnabled` for development instrumentation.
 - TypeScript types including `QRCodeOptions`, `QRCodeProps`, `QRCodeRef`,
   `QRCodeMatrix`, `QRCodeValidationResult`, `QRCodeValidationErrorCode`,
   `QRCodeKnownValidationErrorCode`,
@@ -393,6 +408,9 @@ Main exports:
 | `size`                 | Positive component layout size up to 2048 points; rasterized internally at at least 96 pixels and at least 2x (up to 4096 pixels).   |
 | `quietZone`            | Quiet-zone width in QR modules; integer 0 through 32.                                                                                |
 | `errorCorrectionLevel` | `L`, `M`, `Q`, `H`, or their long-form aliases.                                                                                      |
+| `minVersion` / `maxVersion` | QR version bounds from `1` through `40`, with the minimum no larger than the maximum.                                         |
+| `mask`                 | `-1` for automatic mask selection, or a fixed mask from `0` through `7`.                                                            |
+| `boostEcl`             | Raises error correction within the selected version when the payload fits.                                                         |
 | `scanSafe`             | Raises unsafe defaults; `"strict"` turns scanability warnings into errors.                                                           |
 | `foregroundColor`      | `#RGB`, `#RGBA`, `#RRGGBB`, or `#RRGGBBAA` foreground color.                                                                         |
 | `backgroundColor`      | `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`, or `"transparent"`.                                                                         |
@@ -477,6 +495,13 @@ skipped (with a reason), or failed and never passes silently; use
 device or booted iOS simulator is available. `bun run example:smoke:ci`
 verifies the terminal-state reporting without devices and runs in `check`.
 
+`bun run benchmark:cpp` measures only an isolated optimized native C++ process
+in a temporary build directory. It does not measure React Native mounting,
+canvas rendering, device scanning, or UI responsiveness. The smoke variant uses
+the reduced benchmark run counts and rejects averages above 1,000,000
+microseconds; local timings still vary with compiler and machine load. See the
+[benchmark methodology](docs/benchmarks.md) for the measured cases.
+
 When changing encoder behavior, regenerate and verify the parity corpus with
 `bun scripts/generate-parity-corpus.js` (and `--write` after the native side
 is proven by `bun run --cwd packages/react-native-nitro-qrcode test:cpp`).
@@ -486,6 +511,7 @@ is proven by `bun run --cwd packages/react-native-nitro-qrcode test:cpp`).
 - [npm package](https://www.npmjs.com/package/react-native-nitro-qrcode)
 - [GitHub repository](https://github.com/JoaoPauloCMarra/react-native-nitro-qrcode)
 - [Issues](https://github.com/JoaoPauloCMarra/react-native-nitro-qrcode/issues)
+- [Benchmark methodology](docs/benchmarks.md)
 - [Changelog](https://github.com/JoaoPauloCMarra/react-native-nitro-qrcode/blob/main/CHANGELOG.md)
 
 ## License

--- a/apps/example/app/index.tsx
+++ b/apps/example/app/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import {
   Image,
   Platform,
@@ -13,7 +13,7 @@ import {
 import {
   getMatrix,
   getQRCodeCacheSize,
-  NitroQRCode,
+  getQRCodeMetrics,
   QRCode,
   toPngDataUri,
   toSvgString,
@@ -26,19 +26,19 @@ import {
   type QRCodeEyeBallShape,
   type QRCodeEyeFrameShape,
   type QRCodeGradient,
+  type QRCodeOptions,
   type QRCodeShapeOptions,
 } from "react-native-nitro-qrcode";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 const INITIAL_URL =
   "https://github.com/JoaoPauloCMarra/react-native-nitro-qrcode";
 const PREVIEW_SIZE = 244;
-const METRIC_RASTER_SIZE = PREVIEW_SIZE * 2;
 const APP_ICON = require("../assets/icon.png");
 const PAYLOAD_INITIAL_SELECTION = { start: 0, end: 0 };
 const CONFIG_TABS = ["color", "shapes", "logo"] as const;
 const LOGO_PADDING_PRESETS = ["none", "small", "medium", "large"] as const;
 const BODY_DENSITIES = ["sparse", "balanced", "dense"] as const;
-const BODY_SHAPES = ["square", "circle"] as const;
+const BODY_SHAPES = ["square", "rounded", "circle"] as const;
 const EYE_FRAME_SHAPES = [
   "square",
   "rounded",
@@ -169,15 +169,14 @@ export default function DemoScreen() {
     matrixSize: 0,
     cacheSize: 0,
   });
-  const [readyUri, setReadyUri] = useState("");
+  const [readyKey, setReadyKey] = useState("");
   const [qrError, setQrError] = useState<string | null>(null);
   const [exportPreview, setExportPreview] = useState<string | null>(null);
   const [apiPreview, setApiPreview] = useState<string | null>(null);
-  const [metricsError, setMetricsError] = useState<Error | null>(null);
   const qrRef = useRef<QRCodeRef>(null);
   const hasPayload = value.trim().length > 0;
   const displayError = hasPayload
-    ? (metricsError?.message ?? qrError)
+    ? qrError
     : "Enter a payload to generate a QR code.";
 
   const shapeOptions = useMemo<QRCodeShapeOptions>(
@@ -204,82 +203,45 @@ export default function DemoScreen() {
   const logoAreaSize = showLogo ? 58 : 0;
   const logoAreaBorderRadius = showLogo ? 12 : 0;
   const logoPaddingSize = showLogo ? LOGO_PADDING_CONFIG[logoPadding] : 0;
-
-  useEffect(() => {
-    if (!hasPayload) {
-      return;
-    }
-
-    let isMounted = true;
-    const timeoutId = setTimeout(() => {
-      const startedAt = now();
-      void NitroQRCode.toPngBase64Async({
-        value,
-        size: METRIC_RASTER_SIZE,
-        scanSafe: true,
-        errorCorrectionLevel: showLogo ? "H" : "M",
-        foregroundColor,
-        backgroundColor,
-        strokeColor,
-        eyeColor,
-        eyeStrokeColor,
-        eyeballColor,
-        gradient,
-        shapeOptions: scaleShapeOptions(
-          shapeOptions,
-          METRIC_RASTER_SIZE / PREVIEW_SIZE,
-        ),
-        logoAreaSize: Math.round(
-          logoAreaSize * (METRIC_RASTER_SIZE / PREVIEW_SIZE),
-        ),
-        logoAreaBorderRadius: Math.round(
-          logoAreaBorderRadius * (METRIC_RASTER_SIZE / PREVIEW_SIZE),
-        ),
-      }).then(
-        (png) => {
-          if (!isMounted) {
-            return;
-          }
-
-          const matrix = getMatrix({ value });
-          setMetricsError(null);
-          setMetrics({
-            elapsed: now() - startedAt,
-            bytes: Math.ceil((png.length * 3) / 4),
-            matrixSize: matrix.size,
-            cacheSize: getQRCodeCacheSize(),
-          });
-        },
-        (error: unknown) => {
-          if (!isMounted) {
-            return;
-          }
-          setMetricsError(
-            error instanceof Error ? error : new Error(String(error)),
-          );
-        },
-      );
-    }, 120);
-
-    return () => {
-      isMounted = false;
-      clearTimeout(timeoutId);
-    };
-  }, [
-    backgroundColor,
-    eyeballColor,
-    eyeColor,
-    eyeStrokeColor,
-    foregroundColor,
-    gradient,
-    hasPayload,
-    logoAreaBorderRadius,
-    logoAreaSize,
-    shapeOptions,
-    showLogo,
-    strokeColor,
-    value,
-  ]);
+  const previewOptions = useMemo<QRCodeOptions>(
+    () => ({
+      value,
+      size: PREVIEW_SIZE,
+      scanSafe: true,
+      errorCorrectionLevel: showLogo ? "H" : "M",
+      foregroundColor,
+      backgroundColor,
+      strokeColor,
+      eyeColor,
+      eyeStrokeColor,
+      eyeballColor,
+      gradient,
+      shapeOptions,
+      logoAreaSize,
+      logoAreaBorderRadius,
+    }),
+    [
+      backgroundColor,
+      eyeballColor,
+      eyeColor,
+      eyeStrokeColor,
+      foregroundColor,
+      gradient,
+      logoAreaBorderRadius,
+      logoAreaSize,
+      shapeOptions,
+      showLogo,
+      strokeColor,
+      value,
+    ],
+  );
+  const previewGeneration = useMemo(
+    () => ({
+      key: JSON.stringify(previewOptions),
+    }),
+    [previewOptions],
+  );
+  const isPreviewReady = hasPayload && readyKey === previewGeneration.key;
 
   return (
     <ScrollView
@@ -330,7 +292,16 @@ export default function DemoScreen() {
                     }
                     hideLogoUntilReady
                     onReady={(uri) => {
-                      setReadyUri(uri);
+                      const generationMs =
+                        getQRCodeMetrics().lastGenerationMs ?? 0;
+                      const matrix = getMatrix(previewOptions);
+                      setReadyKey(previewGeneration.key);
+                      setMetrics({
+                        elapsed: generationMs,
+                        bytes: estimateBase64Bytes(uri),
+                        matrixSize: matrix.size,
+                        cacheSize: getQRCodeCacheSize(),
+                      });
                       setQrError(null);
                     }}
                     onError={(error) => {
@@ -363,7 +334,7 @@ export default function DemoScreen() {
               <Tag>
                 {!hasPayload
                   ? "Needs payload"
-                  : readyUri === ""
+                  : !isPreviewReady
                     ? "Pending"
                     : "Ready"}
               </Tag>
@@ -374,9 +345,9 @@ export default function DemoScreen() {
             <Pressable
               accessibilityRole="button"
               accessibilityState={{
-                disabled: !hasPayload || readyUri === "",
+                disabled: !isPreviewReady,
               }}
-              disabled={!hasPayload || readyUri === ""}
+              disabled={!isPreviewReady}
               onPress={() => {
                 const data = qrRef.current?.toPngBase64();
                 setExportPreview(
@@ -387,14 +358,13 @@ export default function DemoScreen() {
               }}
               style={[
                 styles.selectButton,
-                (!hasPayload || readyUri === "") &&
-                  styles.selectButtonDisabled,
+                !isPreviewReady && styles.selectButtonDisabled,
               ]}
             >
               <Text
                 style={[
                   styles.selectButtonText,
-                  (!hasPayload || readyUri === "") && styles.textDisabledDark,
+                  !isPreviewReady && styles.textDisabledDark,
                 ]}
               >
                 Export PNG base64
@@ -408,8 +378,7 @@ export default function DemoScreen() {
               accessibilityState={{ disabled: !hasPayload }}
               disabled={!hasPayload}
               onPress={() => {
-                const options = { value, size: PREVIEW_SIZE } as const;
-                const validation = validateOptions(options);
+                const validation = validateOptions(previewOptions);
                 if (!validation.valid) {
                   setApiPreview(
                     `Invalid options: ${validation.errors[0]?.message ?? "unknown error"}`,
@@ -418,9 +387,9 @@ export default function DemoScreen() {
                 }
 
                 try {
-                  const matrix = getMatrix(options);
-                  const png = toPngDataUri(options);
-                  const svg = toSvgString(options);
+                  const matrix = getMatrix(previewOptions);
+                  const png = toPngDataUri(previewOptions);
+                  const svg = toSvgString(previewOptions);
                   setApiPreview(
                     `Valid · ${matrix.size}×${matrix.size} matrix · PNG ${png.length} chars · SVG ${svg.length} chars`,
                   );
@@ -448,10 +417,9 @@ export default function DemoScreen() {
               accessibilityLabel="QR payload"
               onChangeText={(nextValue) => {
                 setValue(nextValue);
-                setReadyUri("");
+                setReadyKey("");
                 setExportPreview(null);
                 setApiPreview(null);
-                setMetricsError(null);
                 setQrError(null);
                 if (nextValue.trim().length === 0) {
                   setMetrics({
@@ -480,7 +448,11 @@ export default function DemoScreen() {
               value={`${metrics.elapsed.toFixed(2)} ms`}
               tone="green"
             />
-            <FpsMetric />
+            <Metric
+              label="Cache"
+              value={`${metrics.cacheSize}`}
+              tone="amber"
+            />
             <Metric
               label="PNG"
               value={`${formatBytes(metrics.bytes)}`}
@@ -1116,40 +1088,6 @@ function Metric({
   );
 }
 
-function FpsMetric() {
-  const [fps, setFps] = useState(60);
-
-  useEffect(() => {
-    let frameCount = 0;
-    let frameId = 0;
-    let lastFpsTick = 0;
-
-    function tick(timestamp: number) {
-      if (lastFpsTick === 0) {
-        lastFpsTick = timestamp;
-      }
-
-      frameCount += 1;
-      const elapsed = timestamp - lastFpsTick;
-      if (elapsed >= 500) {
-        setFps(Math.round((frameCount * 1000) / elapsed));
-        frameCount = 0;
-        lastFpsTick = timestamp;
-      }
-      frameId = requestAnimationFrame(tick);
-    }
-
-    frameId = requestAnimationFrame(tick);
-    return () => {
-      cancelAnimationFrame(frameId);
-    };
-  }, []);
-
-  return (
-    <Metric label="FPS" value={`${fps}`} tone={fps >= 55 ? "green" : "amber"} />
-  );
-}
-
 function getToneStyle(tone: "green" | "amber" | "blue" | "purple") {
   switch (tone) {
     case "green":
@@ -1163,15 +1101,16 @@ function getToneStyle(tone: "green" | "amber" | "blue" | "purple") {
   }
 }
 
-function now(): number {
-  return typeof performance !== "undefined" ? performance.now() : Date.now();
-}
-
 function formatBytes(bytes: number): string {
   if (bytes < 1024) {
     return `${bytes} B`;
   }
   return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function estimateBase64Bytes(uri: string): number {
+  const base64 = uri.slice("data:image/png;base64,".length);
+  return Math.ceil((base64.length * 3) / 4);
 }
 
 function capitalize(value: string): string {
@@ -1297,30 +1236,6 @@ function isHexColor(value: string): value is QRCodeBackgroundColor {
   return /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(
     value,
   );
-}
-
-function scaleShapeOptions(
-  options: QRCodeShapeOptions,
-  scale: number,
-): QRCodeShapeOptions {
-  return {
-    layout: options.layout,
-    shape: options.shape,
-    eyeFrameShape: options.eyeFrameShape,
-    eyeballShape: options.eyeballShape,
-    eyePatternShape: options.eyePatternShape,
-    bodyDensity: options.bodyDensity,
-    gap: Math.round((options.gap ?? 0) * scale),
-    eyePatternGap: Math.round((options.eyePatternGap ?? 0) * scale),
-    cornerRadius:
-      options.cornerRadius === undefined
-        ? undefined
-        : Math.round(options.cornerRadius * scale),
-    eyePatternCornerRadius:
-      options.eyePatternCornerRadius === undefined
-        ? undefined
-        : Math.round(options.eyePatternCornerRadius * scale),
-  };
 }
 
 const styles = StyleSheet.create({

--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
   ],
   "overrides": {
     "@types/react": "~19.2.18",
+    "caniuse-lite": "1.0.30001810",
     "expo": "~57.0.16",
     "expo-asset": "~57.0.14",
     "expo-constants": "~57.0.14",
@@ -839,7 +840,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.31", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
@@ -871,7 +872,7 @@
 
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -2611,10 +2612,6 @@
 
     "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
-    "@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
-
-    "@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
-
     "@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
@@ -3015,19 +3012,11 @@
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
-
-    "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
-
     "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
     "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/browserslist/update-browserslist-db": ["update-browserslist-db@1.2.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA=="],
-
-    "@babel/plugin-transform-function-name/@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
-
-    "@babel/plugin-transform-function-name/@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
 
     "@babel/plugin-transform-function-name/@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
@@ -3166,10 +3155,6 @@
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "babel-plugin-polyfill-corejs3/core-js-compat/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
-
-    "babel-plugin-polyfill-corejs3/core-js-compat/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
 
     "babel-plugin-polyfill-corejs3/core-js-compat/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
@@ -3323,10 +3308,6 @@
 
     "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "@jest/reporters/istanbul-lib-instrument/@babel/core/@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
-
-    "@jest/reporters/istanbul-lib-instrument/@babel/core/@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
-
     "@jest/reporters/istanbul-lib-instrument/@babel/core/@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "@jest/reporters/istanbul-lib-instrument/@babel/core/@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
@@ -3350,10 +3331,6 @@
     "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/@babel/traverse/@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
     "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-classes/@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg=="],
-
-    "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-classes/@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
 
     "@react-native/metro-babel-transformer/@react-native/babel-preset/@babel/plugin-transform-classes/@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,23 @@
+# Benchmarks
+
+`bun run benchmark:cpp` measures only this package's optimized C++ generator.
+The runner verifies the package identity, compiles a fresh executable in a
+temporary directory, runs that executable in a separate process, reports the
+CSV metrics plus package/runtime metadata, and removes the temporary build
+directory before exiting.
+
+Use the smoke budget in CI or a quick local check:
+
+```sh
+bun run benchmark:cpp:smoke
+```
+
+The smoke build runs 32 fast cases, 8 render cases, and 2 parallel batches per
+benchmark, and rejects any average above 1,000,000 microseconds. Full-run
+timings are directional and should be repeated on the same machine before a
+performance change is considered stable.
+
+The benchmark covers matrix generation, packed base64, cold and cache-hit PNG
+rendering, gradients, styled previews, SVG, base64 encoding, and parallel PNG
+work. It is not a React Native mount or device benchmark; measure those
+separately in the example app.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
+    "caniuse-lite": "1.0.30001810",
     "expo": "~57.0.16",
     "expo-asset": "~57.0.14",
     "expo-constants": "~57.0.14",

--- a/packages/react-native-nitro-qrcode/cpp/core/QRCodeGenerator.cpp
+++ b/packages/react-native-nitro-qrcode/cpp/core/QRCodeGenerator.cpp
@@ -15,7 +15,6 @@
 namespace NitroQRCode {
 namespace {
 
-constexpr uint32_t CrcPolynomial = 0xEDB88320;
 constexpr uint8_t TransparentLayer = 6;
 
 enum class ModuleShape {
@@ -604,15 +603,16 @@ void writeU32(std::vector<uint8_t> &bytes, uint32_t value) {
   bytes.push_back(static_cast<uint8_t>(value & 0xFF));
 }
 
-uint32_t crc32(const uint8_t *data, size_t size) {
-  uint32_t crc = 0xFFFFFFFF;
-  for (size_t i = 0; i < size; i++) {
-    crc ^= data[i];
-    for (int bit = 0; bit < 8; bit++) {
-      crc = (crc >> 1) ^ (CrcPolynomial & (0U - (crc & 1U)));
-    }
+uint32_t crc32Value(const uint8_t *data, size_t size) {
+  uLong crc = ::crc32(0L, Z_NULL, 0);
+  while (size > 0) {
+    const uInt chunkSize = static_cast<uInt>(std::min<size_t>(
+        size, static_cast<size_t>(std::numeric_limits<uInt>::max())));
+    crc = ::crc32(crc, data, chunkSize);
+    data += chunkSize;
+    size -= chunkSize;
   }
-  return crc ^ 0xFFFFFFFF;
+  return static_cast<uint32_t>(crc);
 }
 
 std::string hashCachePart(const std::string &value) {
@@ -643,7 +643,7 @@ void appendChunk(std::vector<uint8_t> &png, const char *type,
   const size_t crcStart = png.size();
   png.insert(png.end(), type, type + 4);
   png.insert(png.end(), data.begin(), data.end());
-  writeU32(png, crc32(png.data() + crcStart, png.size() - crcStart));
+  writeU32(png, crc32Value(png.data() + crcStart, png.size() - crcStart));
 }
 
 std::vector<uint8_t> zlibCompress(const std::vector<uint8_t> &data) {

--- a/packages/react-native-nitro-qrcode/cpp/core/QRCodeGeneratorTest.cpp
+++ b/packages/react-native-nitro-qrcode/cpp/core/QRCodeGeneratorTest.cpp
@@ -67,6 +67,28 @@ uint32_t readU32(const std::vector<uint8_t> &bytes, size_t offset) {
          static_cast<uint32_t>(bytes[offset + 3]);
 }
 
+void assertPngCrcs(const std::string &encoded) {
+  const std::vector<uint8_t> png = base64Decode(encoded);
+  size_t offset = 8;
+  while (offset + 12 <= png.size()) {
+    const uint32_t chunkSize = readU32(png, offset);
+    const size_t typeOffset = offset + 4;
+    const size_t dataOffset = typeOffset + 4;
+    const size_t crcOffset = dataOffset + chunkSize;
+    assert(crcOffset + 4 <= png.size());
+
+    uLong crc = ::crc32(0L, Z_NULL, 0);
+    crc = ::crc32(crc, &png[typeOffset], 4 + chunkSize);
+    assert(static_cast<uint32_t>(crc) == readU32(png, crcOffset));
+
+    offset = crcOffset + 4;
+    if (std::string(reinterpret_cast<const char *>(&png[typeOffset]), 4) ==
+        "IEND") {
+      break;
+    }
+  }
+}
+
 std::vector<uint8_t> decodeRgbaPng(const std::string &encoded, int &width,
                                    int &height) {
   const std::vector<uint8_t> png = base64Decode(encoded);
@@ -189,6 +211,7 @@ void testPngGeneration() {
       generator.renderPngBase64("https://example.com", options);
   assert(!base64.empty());
   assertPngHeader(base64);
+  assertPngCrcs(base64);
 
   const std::string cached =
       generator.renderPngBase64("https://example.com", options);

--- a/packages/react-native-nitro-qrcode/src/__tests__/index.test.tsx
+++ b/packages/react-native-nitro-qrcode/src/__tests__/index.test.tsx
@@ -1418,18 +1418,28 @@ describe("native QRCode API", () => {
         node.props.source?.uri === "data:image/png;base64,accessible",
     )[0];
     expect(image).toBeDefined();
-    expect(image.props.accessible).toBe(true);
-    expect(image.props.accessibilityRole).toBe("image");
-    expect(image.props.accessibilityLabel).toBe(
+    expect(image.props.accessible).toBe(false);
+    expect(image.props.accessibilityElementsHidden).toBe(true);
+    expect(containerWhilePending.props.accessibilityLabel).toBe(
       "QR code for https://example.com/accessible",
     );
+    expect(containerWhilePending.props.accessible).toBe(true);
+    expect(containerWhilePending.props.accessibilityState).toEqual({
+      busy: false,
+    });
 
-    const logo = currentTree.root.findAll(
-      (node) => node.props.accessible === false,
+    const logoContainer = currentTree.root.findAll(
+      (node) =>
+        node.props.accessible === false &&
+        node.children.some(
+          (child) => typeof child !== "string" && String(child.type) === "logo",
+        ),
     )[0];
-    expect(logo).toBeDefined();
-    expect(logo.props.accessibilityElementsHidden).toBe(true);
-    expect(logo.props.importantForAccessibility).toBe("no-hide-descendants");
+    expect(logoContainer).toBeDefined();
+    expect(logoContainer.props.accessibilityElementsHidden).toBe(true);
+    expect(logoContainer.props.importantForAccessibility).toBe(
+      "no-hide-descendants",
+    );
   });
 
   it("uses the default component size", async () => {

--- a/packages/react-native-nitro-qrcode/src/index.ts
+++ b/packages/react-native-nitro-qrcode/src/index.ts
@@ -67,7 +67,7 @@ export {
 
 const NativeQRCode = NitroModules.createHybridObject<HybridQRCode>("QRCode");
 
-function measuredSync<T>(async: boolean, generate: () => T): T {
+function measuredSync<T>(generate: () => T): T {
   if (!isQRCodeMetricsEnabled()) {
     return generate();
   }
@@ -75,14 +75,14 @@ function measuredSync<T>(async: boolean, generate: () => T): T {
   try {
     const result = generate();
     recordGenerationRequest({
-      async,
+      async: false,
       durationMs: nowMilliseconds() - started,
       failed: false,
     });
     return result;
   } catch (error) {
     recordGenerationRequest({
-      async,
+      async: false,
       durationMs: nowMilliseconds() - started,
       failed: true,
     });
@@ -189,14 +189,14 @@ function toNativeMatrixArgs(normalized: NormalizedOptions): NativeMatrixArgs {
 
 export function toPngBase64(options: QRCodeOptions): string {
   const normalized = normalizeOptions(options);
-  return measuredSync(false, () =>
+  return measuredSync(() =>
     NativeQRCode.generatePngBase64Object(toNativeGenerateOptions(normalized)),
   );
 }
 
 export function toPngDataUri(options: QRCodeOptions): string {
   const normalized = normalizeOptions(options);
-  return measuredSync(false, () =>
+  return measuredSync(() =>
     NativeQRCode.generatePngDataUriObject(toNativeGenerateOptions(normalized)),
   );
 }
@@ -225,7 +225,7 @@ export async function toPngDataUriAsync(
 
 export function toSvgString(options: QRCodeOptions): string {
   const normalized = normalizeOptions(options);
-  return measuredSync(false, () =>
+  return measuredSync(() =>
     NativeQRCode.generateSvgString(...toNativeSvgArgs(normalized)),
   );
 }
@@ -233,7 +233,7 @@ export function toSvgString(options: QRCodeOptions): string {
 export function getMatrix(options: QRCodeOptions): QRCodeMatrix {
   const normalized = normalizeOptions(options);
   const nativeArgs = toNativeMatrixArgs(normalized);
-  return measuredSync(false, () => NativeQRCode.getMatrixObject(...nativeArgs));
+  return measuredSync(() => NativeQRCode.getMatrixObject(...nativeArgs));
 }
 
 export function clearQRCodeCache(): void {

--- a/packages/react-native-nitro-qrcode/src/index.web.ts
+++ b/packages/react-native-nitro-qrcode/src/index.web.ts
@@ -76,7 +76,7 @@ export {
   type QRCodeMetricsSnapshot,
 } from "./metrics";
 
-function measuredSync<T>(async: boolean, generate: () => T): T {
+function measuredSync<T>(generate: () => T): T {
   if (!isQRCodeMetricsEnabled()) {
     return generate();
   }
@@ -84,14 +84,14 @@ function measuredSync<T>(async: boolean, generate: () => T): T {
   try {
     const result = generate();
     recordGenerationRequest({
-      async,
+      async: false,
       durationMs: nowMilliseconds() - started,
       failed: false,
     });
     return result;
   } catch (error) {
     recordGenerationRequest({
-      async,
+      async: false,
       durationMs: nowMilliseconds() - started,
       failed: true,
     });
@@ -176,7 +176,7 @@ export function toPngDataUri(options: QRCodeOptions): string {
     return cached;
   }
 
-  return measuredSync(false, () => {
+  return measuredSync(() => {
     const model = createModel(normalized);
     const pixelSize = renderPixelSize(normalized, model);
     const canvas = createCanvas(pixelSize);
@@ -290,7 +290,7 @@ export function toSvgString(options: QRCodeOptions): string {
     return cached;
   }
 
-  return measuredSync(false, () => {
+  return measuredSync(() => {
     const model = createModel(normalized);
     const totalSize = model.modules.size + normalized.quietZone * 2;
     let path = "";

--- a/packages/react-native-nitro-qrcode/src/qrcode-component.ts
+++ b/packages/react-native-nitro-qrcode/src/qrcode-component.ts
@@ -442,14 +442,13 @@ export function createQRCodeComponent(
       {
         style: [styles.frame, { width: size, height: size }, style],
         testID,
-        ...(uri === undefined
-          ? {
-              accessible: true,
-              accessibilityRole: "image" as const,
-              accessibilityLabel: generatingAccessibilityLabel(),
-              accessibilityState: { busy: true },
-            }
-          : {}),
+        accessible: true,
+        accessibilityRole: "image" as const,
+        accessibilityLabel:
+          uri === undefined
+            ? generatingAccessibilityLabel()
+            : qrCodeAccessibilityLabel(value),
+        accessibilityState: { busy: uri === undefined },
       },
       uri === undefined && placeholder,
       uri !== undefined &&
@@ -457,9 +456,9 @@ export function createQRCodeComponent(
           source: { uri },
           resizeMode: "contain",
           style: [styles.image, imageStyle],
-          accessible: true,
-          accessibilityRole: "image",
-          accessibilityLabel: qrCodeAccessibilityLabel(value),
+          accessible: false,
+          accessibilityElementsHidden: true,
+          importantForAccessibility: "no-hide-descendants",
           ...(generators.accessibilityIgnoresInvertColors !== undefined
             ? {
                 accessibilityIgnoresInvertColors:

--- a/scripts/assert-example-smoke.js
+++ b/scripts/assert-example-smoke.js
@@ -63,12 +63,18 @@ function waitForAndroidUi() {
     );
 
     if (dump.status === 0) {
-      const output = run("adb", ["shell", "cat", dumpPath]);
-      try {
-        assertVisible(output, "Android");
-        return;
-      } catch (error) {
-        lastError = error instanceof Error ? error.message : String(error);
+      const read = spawnSync("adb", ["shell", "cat", dumpPath], {
+        encoding: "utf8",
+      });
+      if (read.status === 0) {
+        try {
+          assertVisible(read.stdout, "Android");
+          return;
+        } catch (error) {
+          lastError = error instanceof Error ? error.message : String(error);
+        }
+      } else {
+        lastError = `UI dump read exited with ${read.status ?? "no status"}`;
       }
     } else {
       lastError = `uiautomator dump exited with ${dump.status ?? "no status"}`;

--- a/scripts/benchmark-cpp.js
+++ b/scripts/benchmark-cpp.js
@@ -1,5 +1,6 @@
 const { execFileSync, execSync } = require("child_process");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 const packageDir = path.join(
@@ -8,10 +9,19 @@ const packageDir = path.join(
   "packages",
   "react-native-nitro-qrcode"
 );
+const packageManifest = require(path.join(packageDir, "package.json"));
 const cppDir = path.join(packageDir, "cpp");
-const buildDir = path.join(cppDir, "build");
+const buildDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), "react-native-nitro-qrcode-benchmark-"),
+);
 const outputFile = path.join(buildDir, "qrcode_generator_benchmark");
 const smoke = process.argv.includes("--smoke");
+
+if (packageManifest.name !== "react-native-nitro-qrcode") {
+  throw new Error(
+    `Benchmark setup failed: expected react-native-nitro-qrcode, got ${packageManifest.name}.`,
+  );
+}
 
 const PINNED_LLVM_VERSION = 18;
 
@@ -42,8 +52,24 @@ function runCommand(command, args) {
   });
 }
 
-fs.rmSync(buildDir, { recursive: true, force: true });
-fs.mkdirSync(buildDir, { recursive: true });
+function parseBenchmarkOutput(output) {
+  const lines = output.trim().split(/\r?\n/);
+  const headerIndex = lines.indexOf("benchmark,runs,total_us,avg_us");
+  if (headerIndex < 0) {
+    throw new Error("C++ benchmark did not emit its CSV header");
+  }
+
+  return lines
+    .slice(headerIndex + 1)
+    .map((line) => line.split(","))
+    .filter((parts) => parts.length === 4)
+    .map(([benchmark, runs, totalUs, averageUs]) => ({
+      benchmark,
+      runs: Number(runs),
+      totalUs: Number(totalUs),
+      averageUs: Number(averageUs),
+    }));
+}
 
 const sources = [
   path.join(cppDir, "core", "QRCodeGeneratorBenchmark.cpp"),
@@ -69,27 +95,48 @@ const compileArgs = [
 ];
 
 console.log("Compiling optimized C++ QRCode benchmark...");
-runCommand(resolveTool("clang++"), compileArgs);
+try {
+  runCommand(resolveTool("clang++"), compileArgs);
 
-console.log("Running C++ QRCode benchmark...");
-if (!smoke) {
-  runCommand(outputFile, []);
-} else {
-  const output = execFileSync(outputFile, [], { encoding: "utf8" });
+  console.log(
+    `Benchmark package: ${packageManifest.name}@${packageManifest.version}`,
+  );
+  console.log(
+    "Benchmark scope: isolated optimized C++ process with a temporary build directory; no repository build state is reused.",
+  );
+  console.log("Running C++ QRCode benchmark...");
+  const output = execFileSync(outputFile, [], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
   process.stdout.write(output);
-  const ceilingMicros = 1_000_000;
-  const regressions = output
-    .trim()
-    .split("\n")
-    .slice(1)
-    .map((line) => line.split(","))
-    .filter((parts) => parts.length === 4)
-    .filter((parts) => Number(parts[3]) > ceilingMicros);
-  if (regressions.length > 0) {
-    throw new Error(
-      `C++ benchmark smoke exceeded ${ceilingMicros} average microseconds: ${regressions
-        .map((parts) => `${parts[0]}=${parts[3]}`)
-        .join(", ")}`,
+  const metrics = parseBenchmarkOutput(output);
+  if (smoke) {
+    const ceilingMicros = 1_000_000;
+    const regressions = metrics.filter(
+      (metric) => metric.averageUs > ceilingMicros,
     );
+    if (regressions.length > 0) {
+      throw new Error(
+        `C++ benchmark smoke exceeded ${ceilingMicros} average microseconds: ${regressions
+          .map((metric) => `${metric.benchmark}=${metric.averageUs}`)
+          .join(", ")}`,
+      );
+    }
   }
+  console.log(
+    `BENCHMARK_RESULT ${JSON.stringify({
+      package: packageManifest.name,
+      version: packageManifest.version,
+      benchmark: "native-cpp-qrcode",
+      scope: "isolated-native-cpp-process",
+      smoke,
+      compiler: "clang++ -O3 -DNDEBUG",
+      metrics,
+      platform: process.platform,
+      architecture: process.arch,
+    })}`,
+  );
+} finally {
+  fs.rmSync(buildDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
# Changes
- Use zlib chunk CRC calculation for native PNG output and cover every generated PNG chunk.
- Avoid duplicate preview generation, remove permanent frame polling, and expose accurate generation and cache metrics.
- Fix preview accessibility completion state and preserve customizable native and web rendering contracts.
- Harden Android and iOS smoke retries and add isolated native benchmark documentation.
- Breaking changes: none.
