### PR TITLE
Release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes are always listed first in each release section.
 
+## [0.7.2] - 2026-09-10
+
+### Breaking changes
+
+- None.
+
+### Fixed
+
+- iOS builds using static frameworks and source-built React Native now resolve
+  Folly and React Native headers when compiling the Nitro Swift/C++ bridge.
+
 ## [0.7.1] - 2026-09-09
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Direct upgrades from 0.5.x or earlier still require the Nitro 0.37 native
 rebuild described above. Review the matching [0.6.0 changelog entry](https://github.com/JoaoPauloCMarra/react-native-nitro-qrcode/blob/main/CHANGELOG.md#060---2026-08-20)
 when skipping releases.
 
+iOS static frameworks are supported with source-built React Native. After
+upgrading, regenerate the Expo native project or run `pod install`, then rebuild
+the app so CocoaPods applies the updated header paths.
+
 ## Expo Config
 
 No app config options are required.

--- a/packages/react-native-nitro-qrcode/package.json
+++ b/packages/react-native-nitro-qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-qrcode",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Fast QR code generator for React Native and Expo with Nitro, native C++, PNG export, gradients, and no react-native-svg or Skia.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-nitro-qrcode/react-native-nitro-qrcode.podspec
+++ b/packages/react-native-nitro-qrcode/react-native-nitro-qrcode.podspec
@@ -40,4 +40,5 @@ Pod::Spec.new do |s|
   
   load 'nitrogen/generated/ios/NitroQRCode+autolinking.rb'
   add_nitrogen_files(s)
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
# Summary

Fix iOS compilation with static frameworks and source-built React Native in react-native-nitro-qrcode 0.7.2.

# Changes

- Apply React Native dependency configuration after Nitro autolinking so the Swift/C++ bridge can resolve Folly and React Native headers.
- Update the patch version, changelog, and iOS rebuild guidance.
